### PR TITLE
Fix HACS error when adding repository

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
     "name": "threedy",
-    "content_in_root": false,
-    "zip_release": false,
     "filename": "threedy-card.js",
     "render_readme": true
 }


### PR DESCRIPTION
HACS was reporting `Repostitory structure for master is not compliant` which is very odd.
However, removing all the configuration makes it work.

You can test it with a testrelease in my fork: https://github.com/Jan-Ka/threedy/releases/tag/2021.0.b1
Just add `https://github.com/Jan-Ka/threedy`